### PR TITLE
Move application_manager_impl unit tests from pre_5_0 branch to develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 script:
   - sudo ln -sf /usr/bin/gcov-4.9 /usr/bin/gcov
   - bash -e tools/infrastructure/check_style.sh
-  - echo Number of processing units available: ${PROCESSING_UNITS_COUNT}
+  - echo "Number of processing units available ${PROCESSING_UNITS_COUNT}"
   - mkdir build && cd build && cmake ../ -DBUILD_TESTS=ON -DENABLE_GCOV=ON && make install -j${PROCESSING_UNITS_COUNT}
   - sudo ldconfig
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/bin/lib ; make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ before_install:
 script:
   - sudo ln -sf /usr/bin/gcov-4.9 /usr/bin/gcov
   - bash -e tools/infrastructure/check_style.sh
-  - mkdir build && cd build && cmake ../ -DBUILD_TESTS=ON -DENABLE_GCOV=ON && make install
+  - echo Number of processing units available: ${PROCESSING_UNITS_COUNT}
+  - mkdir build && cd build && cmake ../ -DBUILD_TESTS=ON -DENABLE_GCOV=ON && make install -j${PROCESSING_UNITS_COUNT}
   - sudo ldconfig
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/bin/lib ; make test
   - bash ../tools/infrastructure/show_disabled.sh 
@@ -45,6 +46,7 @@ env:
   - CMAKE_CXX_COMPILER=g++-4.9
   - CMAKE_C_COMPILER=gcc-4.9
   - LD_LIBRARY_PATH=.
+  - PROCESSING_UNITS_COUNT=$("nproc")
 after_success:
   - pwd ; bash <(curl -s https://codecov.io/bash) -f ./coverage/coverage.info || echo "Codecov did not collect coverage reports"
 deploy:

--- a/src/appMain/CMakeLists.txt
+++ b/src/appMain/CMakeLists.txt
@@ -145,10 +145,6 @@ target_link_libraries(${PROJECT} ${LIBRARIES})
 
 add_dependencies(${PROJECT} Policy)
 
-if(ENABLE_LOG)
-  add_dependencies(${PROJECT} install-3rd_party_logger)
-endif()
-
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/log4cxx.properties DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/audio.8bit.wav DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/test.txt DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/appMain/CMakeLists.txt
+++ b/src/appMain/CMakeLists.txt
@@ -143,6 +143,12 @@ endif()
 add_executable(${PROJECT} ${SOURCES})
 target_link_libraries(${PROJECT} ${LIBRARIES})
 
+add_dependencies(${PROJECT} Policy)
+
+if(ENABLE_LOG)
+  add_dependencies(${PROJECT} install-3rd_party_logger)
+endif()
+
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/log4cxx.properties DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/audio.8bit.wav DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/test.txt DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/components/application_manager/CMakeLists.txt
+++ b/src/components/application_manager/CMakeLists.txt
@@ -363,10 +363,10 @@ set (HMI_COMMANDS_SOURCES_DBUS
 )
 
 if (${HMI_JSON_API})
-    set (HMI_COMMANDS_SOURCES ${HMI_COMMANDS_SOURCES} ${HMI_COMMANDS_SOURCES_JSON})
+  set (HMI_COMMANDS_SOURCES ${HMI_COMMANDS_SOURCES} ${HMI_COMMANDS_SOURCES_JSON})
 endif (${HMI_JSON_API})
 if (${HMI_DBUS_API})
-    set (HMI_COMMANDS_SOURCES ${HMI_COMMANDS_SOURCES} ${HMI_COMMANDS_SOURCES_DBUS})
+  set (HMI_COMMANDS_SOURCES ${HMI_COMMANDS_SOURCES} ${HMI_COMMANDS_SOURCES_DBUS})
 endif (${HMI_DBUS_API})
 
 set(EXCLUDE_PATHS
@@ -392,6 +392,7 @@ set(LIBRARIES
   dl
   formatters
   dbms
+  Utils
 )
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -406,15 +407,16 @@ add_library("AMEventEngine" ${EVENT_ENGINE_SOURCES})
 target_link_libraries("AMEventEngine" ${LIBRARIES})
 
 add_library("AMPolicyLibrary" ${POLICIES_MANAGER_SOURCES} )
-target_link_libraries("AMPolicyLibrary" ${LIBRARIES} AMEventEngine)
+target_link_libraries("AMPolicyLibrary" ${LIBRARIES})
 
 add_library("AMHMICommandsLibrary" ${HMI_COMMANDS_SOURCES})
-target_link_libraries("AMHMICommandsLibrary" ${LIBRARIES} AMEventEngine)
+target_link_libraries("AMHMICommandsLibrary" ${LIBRARIES})
 
 add_library("MessageHelper" ${MESSAGE_HELPER_SOURCES})
+target_link_libraries("MessageHelper" ${LIBRARIES})
 
 add_library("AMMobileCommandsLibrary" ${MOBILE_COMMANDS_SOURCES} )
-target_link_libraries("AMMobileCommandsLibrary" ${LIBRARIES} AMEventEngine)
+target_link_libraries("AMMobileCommandsLibrary" ${LIBRARIES})
 
 add_library("ApplicationManager" ${SOURCES})
 

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -259,6 +259,20 @@ class CommandRequestImpl : public CommandImpl,
   mobile_apis::Result::eType PrepareResultCodeForResponse(
       const ResponseInfo& first, const ResponseInfo& second);
 
+  /**
+   * @brief Resolves if the return code must be
+   * UNSUPPORTED_RESOURCE
+   * @param first contains result_code from HMI response and
+   * interface that returns response
+   * @param second contains result_code from HMI response and
+   * interface that returns response.
+   * @return if the communication return code must be
+   * UNSUPPORTED_RESOURCE, function returns true, else
+   * false
+   */
+  bool IsResultCodeUnsupported(const ResponseInfo& first,
+                               const ResponseInfo& second) const;
+
  protected:
   /**
    * @brief Returns policy parameters permissions

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -272,6 +272,16 @@ class CommandRequestImpl : public CommandImpl,
    */
   bool IsResultCodeUnsupported(const ResponseInfo& first,
                                const ResponseInfo& second) const;
+  /**
+   * @brief Checks result code from HMI for split RPC
+   * and set flags to the info structures.
+   * @param first contains result_code from HMI response and
+   * interface that returns response
+   * @param second contains result_code from HMI response and
+   * interface that returns response
+   */
+  void SetResultCodeFlagsForHMIResponses(ResponseInfo& out_first,
+                                         ResponseInfo& out_second) const;
 
  protected:
   /**

--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
@@ -136,7 +136,7 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
   /**
    * @brief Validates audioPassThruIcon parameter and
    * removes it if is not valid
-   * @param Pointer to the application whose storage directory
+   * @param app Pointer to the application whose storage directory
    * must be accessed
    */
   void ProcessAudioPassThruIcon(ApplicationSharedPtr app);
@@ -154,7 +154,7 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
   /**
    * @brief Maintains the full path filename for the
    * audioPassThruIcon file
-   * @param Pointer to the application whose storage directory
+   * @param app Pointer to the application whose storage directory
    * must be accessed
    */
   std::string GetAudioPassThruIconFilename(ApplicationSharedPtr app);
@@ -174,8 +174,8 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
   /**
    * @brief Checks if any of audioPassThru communication components
    * returned ABORTED code
-   * @param ui_response contains result_code from UI
-   * @param tts_response contains result_code from TTS
+   * @param ui contains result_code from UI
+   * @param tts contains result_code from TTS
    * @return if TTS or UI responded with ABORTED function returns TRUE,
    * else is returns FALSE
    */

--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
@@ -133,10 +133,64 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
    */
   bool IsWaitingHMIResponse();
 
+  /**
+   * @brief Validates audioPassThruIcon parameter and
+   * removes it if is not valid
+   * @param Pointer to the application whose storage directory
+   * must be accessed
+   */
+  void ProcessAudioPassThruIcon(ApplicationSharedPtr app);
+
+  /**
+   * @brief Checks if the audioPassThruIcon parameter value
+   * contains special characters (\n,\t) or
+   * contains only white spaces
+   * @return If the audioPassthruIcon parameter value contains
+   * above mentioned symbols, the function returns FALSE, else
+   * the parameter value is valid and it returns TRUE
+   */
+  bool IsAudioPassThruIconParamValid();
+
+  /**
+   * @brief Maintains the full path filename for the
+   * audioPassThruIcon file
+   * @param Pointer to the application whose storage directory
+   * must be accessed
+   */
+  std::string GetAudioPassThruIconFilename(ApplicationSharedPtr app);
+
+  /**
+   * @brief Checks result code from HMI for splitted RPC
+   * and returns parameter for sending to mobile app in
+   * audioPassThru communication.
+   * @param ui_response contains result_code from UI
+   * @param tts_response contains result_code from TTS
+   * @return result code - 1) UI error code has precedence than TTS's
+   * 2) error_code from TTS is turned to WARNINGS
+   */
+  mobile_apis::Result::eType PrepareAudioPassThruResultCodeForResponse(
+      const ResponseInfo& ui_response, const ResponseInfo& tts_response);
+
+  /**
+   * @brief Checks if any of audioPassThru communication components
+   * returned ABORTED code
+   * @param ui_response contains result_code from UI
+   * @param tts_response contains result_code from TTS
+   * @return if TTS or UI responded with ABORTED function returns TRUE,
+   * else is returns FALSE
+   */
+  bool IsAnyHMIComponentAborted(const ResponseInfo& ui,
+                                const ResponseInfo& tts);
+
   /* flag display state of speak and ui perform audio
   during perform audio pass thru*/
   bool awaiting_tts_speak_response_;
   bool awaiting_ui_response_;
+
+  /* flag shows if last received audioPassThruIcon exists
+   * in the file system
+   */
+  bool audio_pass_thru_icon_exists_;
 
   hmi_apis::Common_Result::eType result_tts_speak_;
   hmi_apis::Common_Result::eType result_ui_;

--- a/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
+++ b/src/components/application_manager/include/application_manager/commands/mobile/perform_audio_pass_thru_request.h
@@ -152,14 +152,6 @@ class PerformAudioPassThruRequest : public CommandRequestImpl {
   bool IsAudioPassThruIconParamValid();
 
   /**
-   * @brief Maintains the full path filename for the
-   * audioPassThruIcon file
-   * @param app Pointer to the application whose storage directory
-   * must be accessed
-   */
-  std::string GetAudioPassThruIconFilename(ApplicationSharedPtr app);
-
-  /**
    * @brief Checks result code from HMI for splitted RPC
    * and returns parameter for sending to mobile app in
    * audioPassThru communication.

--- a/src/components/application_manager/include/application_manager/hmi_language_handler.h
+++ b/src/components/application_manager/include/application_manager/hmi_language_handler.h
@@ -181,11 +181,6 @@ class HMILanguageHandler : public event_engine::EventObserver {
   bool is_tts_language_received_;
   resumption::LastState* last_state_;
   ApplicationManager& application_manager_;
-
-#ifdef BUILD_TESTS
- public:
-  const Apps& get_apps() const;
-#endif  // BUILD_TESTS
 };
 
 }  // namespace application_manager

--- a/src/components/application_manager/include/application_manager/hmi_language_handler.h
+++ b/src/components/application_manager/include/application_manager/hmi_language_handler.h
@@ -181,6 +181,11 @@ class HMILanguageHandler : public event_engine::EventObserver {
   bool is_tts_language_received_;
   resumption::LastState* last_state_;
   ApplicationManager& application_manager_;
+
+#ifdef BUILD_TESTS
+ public:
+  const Apps& get_apps() const;
+#endif  // BUILD_TESTS
 };
 
 }  // namespace application_manager

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -164,6 +164,7 @@ extern const char* speech_capabilities;
 extern const char* vr_capabilities;
 extern const char* audio_pass_thru_capabilities;
 extern const char* pcm_stream_capabilities;
+extern const char* audio_pass_thru_icon;
 
 // PutFile
 extern const char* sync_file_name;

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -681,6 +681,18 @@ bool CommandRequestImpl::PrepareResultForMobileResponse(
 
 bool CommandRequestImpl::PrepareResultForMobileResponse(
     ResponseInfo& out_first, ResponseInfo& out_second) const {
+  SetResultCodeFlagsForHMIResponses(out_first, out_second);
+
+  bool result = (out_first.is_ok && out_second.is_ok) ||
+                (out_second.is_invalid_enum && out_first.is_ok) ||
+                (out_first.is_invalid_enum && out_second.is_ok);
+  result = result || CheckResultCode(out_first, out_second);
+  result = result || CheckResultCode(out_second, out_first);
+  return result;
+}
+
+void CommandRequestImpl::SetResultCodeFlagsForHMIResponses(
+    ResponseInfo& out_first, ResponseInfo& out_second) const {
   using namespace helpers;
 
   out_first.is_ok = Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
@@ -717,13 +729,6 @@ bool CommandRequestImpl::PrepareResultForMobileResponse(
   out_second.interface_state =
       application_manager_.hmi_interfaces().GetInterfaceState(
           out_second.interface);
-
-  bool result = (out_first.is_ok && out_second.is_ok) ||
-                (out_second.is_invalid_enum && out_first.is_ok) ||
-                (out_first.is_invalid_enum && out_second.is_ok);
-  result = result || CheckResultCode(out_first, out_second);
-  result = result || CheckResultCode(out_second, out_first);
-  return result;
 }
 
 void CommandRequestImpl::GetInfo(

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -109,15 +109,6 @@ bool CheckResultCode(const ResponseInfo& first, const ResponseInfo& second) {
   return false;
 }
 
-bool IsResultCodeUnsupported(const ResponseInfo& first,
-                             const ResponseInfo& second) {
-  return ((first.is_ok || first.is_invalid_enum) &&
-          second.is_unsupported_resource) ||
-         ((second.is_ok || second.is_invalid_enum) &&
-          first.is_unsupported_resource) ||
-         (first.is_unsupported_resource && second.is_unsupported_resource);
-}
-
 struct DisallowedParamsInserter {
   DisallowedParamsInserter(smart_objects::SmartObject& response,
                            mobile_apis::VehicleDataResultCode::eType code)
@@ -773,6 +764,15 @@ mobile_apis::Result::eType CommandRequestImpl::PrepareResultCodeForResponse(
 const CommandParametersPermissions& CommandRequestImpl::parameters_permissions()
     const {
   return parameters_permissions_;
+}
+
+bool CommandRequestImpl::IsResultCodeUnsupported(
+    const ResponseInfo& first, const ResponseInfo& second) const {
+  return ((first.is_ok || first.is_invalid_enum) &&
+          second.is_unsupported_resource) ||
+         ((second.is_ok || second.is_invalid_enum) &&
+          first.is_unsupported_resource) ||
+         (first.is_unsupported_resource && second.is_unsupported_resource);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/hmi/on_exit_application_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_exit_application_notification.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Ford Motor Company
+ * Copyright (c) 2017, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -68,11 +68,6 @@ void OnExitApplicationNotification::Run() {
 
   switch (reason) {
     case Common_ApplicationExitReason::DRIVER_DISTRACTION_VIOLATION: {
-      application_manager_.ManageMobileCommand(
-          MessageHelper::GetOnAppInterfaceUnregisteredNotificationToMobile(
-              app_id,
-              AppInterfaceUnregisteredReason::DRIVER_DISTRACTION_VIOLATION),
-          commands::Command::ORIGIN_SDL);
       break;
     }
     case Common_ApplicationExitReason::USER_EXIT: {
@@ -100,13 +95,9 @@ void OnExitApplicationNotification::Run() {
       return;
     }
   }
-  ApplicationSharedPtr app = application_manager_.application(app_id);
-  if (app) {
-    application_manager_.state_controller().SetRegularState(
-        app, HMILevel::HMI_NONE, AudioStreamingState::NOT_AUDIBLE, false);
-  } else {
-    LOG4CXX_ERROR(logger_, "Unable to find appication " << app_id);
-  }
+
+  application_manager_.state_controller().SetRegularState(
+      app_impl, HMILevel::HMI_NONE, AudioStreamingState::NOT_AUDIBLE, false);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -394,9 +394,10 @@ void PerformAudioPassThruRequest::ProcessAudioPassThruIcon(
   if ((*message_)[strings::msg_params].keyExists(
           strings::audio_pass_thru_icon)) {
     if (IsAudioPassThruIconParamValid()) {
-      const std::string& icon_storage_file = GetAudioPassThruIconFilename(app);
-
-      if (!file_system::FileExists(icon_storage_file)) {
+      smart_objects::SmartObject icon =
+          (*message_)[strings::msg_params][strings::audio_pass_thru_icon];
+      if (MessageHelper::VerifyImage(icon, app, application_manager_) !=
+          mobile_apis::Result::SUCCESS) {
         LOG4CXX_WARN(
             logger_,
             "Invalid audio_pass_thru_icon doesn't exist in the file system");
@@ -423,8 +424,6 @@ PerformAudioPassThruRequest::PrepareAudioPassThruResultCodeForResponse(
   if ((ui_result == hmi_apis::Common_Result::SUCCESS) &&
       (tts_result != hmi_apis::Common_Result::SUCCESS)) {
     common_result = hmi_apis::Common_Result::WARNINGS;
-  } else if (tts_result == hmi_apis::Common_Result::ABORTED) {
-    common_result = hmi_apis::Common_Result::ABORTED;
   } else if (ui_result == hmi_apis::Common_Result::INVALID_ENUM) {
     common_result = tts_result;
   } else {
@@ -449,21 +448,6 @@ bool PerformAudioPassThruRequest::IsAudioPassThruIconParamValid() {
   }
 
   return true;
-}
-
-std::string PerformAudioPassThruRequest::GetAudioPassThruIconFilename(
-    ApplicationSharedPtr app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  const std::string& str =
-      (*message_)[strings::msg_params][strings::audio_pass_thru_icon]
-                 [strings::value].asString();
-  const std::string storage_directory(
-      application_manager_.get_settings().app_storage_folder() + "/");
-  const std::string icon_storage_file(storage_directory + app->folder_name() +
-                                      "/" + str);
-
-  return icon_storage_file;
 }
 
 bool PerformAudioPassThruRequest::IsAnyHMIComponentAborted(

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -201,10 +201,7 @@ bool PerformAudioPassThruRequest::PrepareResponseParameters(
   ResponseInfo tts_perform_info(result_tts_speak_,
                                 HmiInterfaces::HMI_INTERFACE_TTS);
 
-  bool result_unused =
-      PrepareResultForMobileResponse(ui_perform_info, tts_perform_info);
-  UNUSED(result_unused);
-
+  SetResultCodeFlagsForHMIResponses(ui_perform_info, tts_perform_info);
   if (ui_perform_info.is_ok && tts_perform_info.is_unsupported_resource &&
       HmiInterfaces::STATE_AVAILABLE == tts_perform_info.interface_state) {
     result_code = mobile_apis::Result::WARNINGS;

--- a/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -37,6 +37,7 @@
 #include "application_manager/application_impl.h"
 #include "application_manager/message_helper.h"
 #include "utils/helpers.h"
+#include "utils/file_system.h"
 
 namespace application_manager {
 
@@ -49,6 +50,7 @@ PerformAudioPassThruRequest::PerformAudioPassThruRequest(
     : CommandRequestImpl(message, application_manager)
     , awaiting_tts_speak_response_(false)
     , awaiting_ui_response_(false)
+    , audio_pass_thru_icon_exists_(true)
     , result_tts_speak_(hmi_apis::Common_Result::INVALID_ENUM)
     , result_ui_(hmi_apis::Common_Result::INVALID_ENUM) {
   subscribe_on_event(hmi_apis::FunctionID::TTS_OnResetTimeout);
@@ -97,6 +99,7 @@ void PerformAudioPassThruRequest::Run() {
   // According with new implementation processing of UNSUPPORTE_RESOURCE
   // need set flag before sending to hmi
 
+  ProcessAudioPassThruIcon(app);
   awaiting_ui_response_ = true;
   if ((*message_)[str::msg_params].keyExists(str::initial_prompt) &&
       (0 < (*message_)[str::msg_params][str::initial_prompt].length())) {
@@ -193,21 +196,35 @@ bool PerformAudioPassThruRequest::PrepareResponseParameters(
     mobile_apis::Result::eType& result_code, std::string& info) {
   LOG4CXX_AUTO_TRACE(logger_);
 
+  bool result = true;
   ResponseInfo ui_perform_info(result_ui_, HmiInterfaces::HMI_INTERFACE_UI);
   ResponseInfo tts_perform_info(result_tts_speak_,
                                 HmiInterfaces::HMI_INTERFACE_TTS);
-  const bool result =
-      PrepareResultForMobileResponse(ui_perform_info, tts_perform_info);
+
+  PrepareResultForMobileResponse(ui_perform_info, tts_perform_info);
 
   if (ui_perform_info.is_ok && tts_perform_info.is_unsupported_resource &&
       HmiInterfaces::STATE_AVAILABLE == tts_perform_info.interface_state) {
     result_code = mobile_apis::Result::WARNINGS;
     tts_info_ = "Unsupported phoneme type sent in a prompt";
-    info = MergeInfos(ui_perform_info, ui_info_, tts_perform_info, tts_info_);
-    return result;
+  } else if (IsResultCodeUnsupported(ui_perform_info, tts_perform_info)) {
+    result_code = mobile_apis::Result::UNSUPPORTED_RESOURCE;
+  } else if (IsAnyHMIComponentAborted(ui_perform_info, tts_perform_info)) {
+    result_code = mobile_apis::Result::ABORTED;
+    result = false;
+  } else {
+    result_code = PrepareAudioPassThruResultCodeForResponse(ui_perform_info,
+                                                            tts_perform_info);
+    if (!ui_perform_info.is_ok) {
+      result = false;
+    }
   }
-  result_code = PrepareResultCodeForResponse(ui_perform_info, tts_perform_info);
+
   info = MergeInfos(ui_perform_info, ui_info_, tts_perform_info, tts_info_);
+  if (audio_pass_thru_icon_exists_ == false) {
+    info = MergeInfos("Reference image(s) not found", info);
+  }
+
   return result;
 }
 
@@ -271,6 +288,11 @@ void PerformAudioPassThruRequest::SendPerformAudioPassThruRequest() {
   } else {
     // If omitted, the value is set to true
     msg_params[str::mute_audio] = true;
+  }
+
+  if ((*message_)[str::msg_params].keyExists(str::audio_pass_thru_icon)) {
+    msg_params[str::audio_pass_thru_icon] =
+        (*message_)[str::msg_params][str::audio_pass_thru_icon];
   }
 
   SendHMIRequest(
@@ -363,6 +385,93 @@ void PerformAudioPassThruRequest::FinishTTSSpeak() {
 bool PerformAudioPassThruRequest::IsWaitingHMIResponse() {
   LOG4CXX_AUTO_TRACE(logger_);
   return awaiting_tts_speak_response_ || awaiting_ui_response_;
+}
+
+void PerformAudioPassThruRequest::ProcessAudioPassThruIcon(
+    ApplicationSharedPtr app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  audio_pass_thru_icon_exists_ = true;
+  if ((*message_)[strings::msg_params].keyExists(
+          strings::audio_pass_thru_icon)) {
+    if (IsAudioPassThruIconParamValid()) {
+      const std::string& icon_storage_file = GetAudioPassThruIconFilename(app);
+
+      if (!file_system::FileExists(icon_storage_file)) {
+        LOG4CXX_WARN(
+            logger_,
+            "Invalid audio_pass_thru_icon doesn't exist in the file system");
+        audio_pass_thru_icon_exists_ = false;
+      }
+    } else {
+      LOG4CXX_WARN(logger_,
+                   "Invalid audio_pass_thru_icon validation check failed");
+      (*message_)[strings::msg_params].erase(strings::audio_pass_thru_icon);
+    }
+  }
+}
+
+mobile_apis::Result::eType
+PerformAudioPassThruRequest::PrepareAudioPassThruResultCodeForResponse(
+    const ResponseInfo& ui_response, const ResponseInfo& tts_response) {
+  mobile_apis::Result::eType result_code = mobile_apis::Result::INVALID_ENUM;
+
+  hmi_apis::Common_Result::eType common_result =
+      hmi_apis::Common_Result::INVALID_ENUM;
+  const hmi_apis::Common_Result::eType ui_result = ui_response.result_code;
+  const hmi_apis::Common_Result::eType tts_result = tts_response.result_code;
+
+  if ((ui_result == hmi_apis::Common_Result::SUCCESS) &&
+      (tts_result != hmi_apis::Common_Result::SUCCESS)) {
+    common_result = hmi_apis::Common_Result::WARNINGS;
+  } else if (tts_result == hmi_apis::Common_Result::ABORTED) {
+    common_result = hmi_apis::Common_Result::ABORTED;
+  } else if (ui_result == hmi_apis::Common_Result::INVALID_ENUM) {
+    common_result = tts_result;
+  } else {
+    common_result = ui_result;
+  }
+
+  result_code = MessageHelper::HMIToMobileResult(common_result);
+  return result_code;
+}
+
+bool PerformAudioPassThruRequest::IsAudioPassThruIconParamValid() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const std::string& value =
+      (*message_)[strings::msg_params][strings::audio_pass_thru_icon]
+                 [strings::value].asString();
+
+  if (!CheckSyntax(value, false)) {
+    LOG4CXX_WARN(logger_,
+                 "Invalid audio_pass_thru_icon value syntax check failed");
+    return false;
+  }
+
+  return true;
+}
+
+std::string PerformAudioPassThruRequest::GetAudioPassThruIconFilename(
+    ApplicationSharedPtr app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const std::string& str =
+      (*message_)[strings::msg_params][strings::audio_pass_thru_icon]
+                 [strings::value].asString();
+  const std::string storage_directory(
+      application_manager_.get_settings().app_storage_folder() + "/");
+  const std::string icon_storage_file(storage_directory + app->folder_name() +
+                                      "/" + str);
+
+  return icon_storage_file;
+}
+
+bool PerformAudioPassThruRequest::IsAnyHMIComponentAborted(
+    const ResponseInfo& ui, const ResponseInfo& tts) {
+  using namespace helpers;
+
+  return ((ui.result_code == hmi_apis::Common_Result::ABORTED) ||
+          (tts.result_code == hmi_apis::Common_Result::ABORTED));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/hmi_language_handler.cc
+++ b/src/components/application_manager/src/hmi_language_handler.cc
@@ -346,6 +346,12 @@ void HMILanguageHandler::Init(resumption::LastState* value) {
   persisted_tts_language_ = get_language_for(INTERFACE_TTS);
 }
 
+#ifdef BUILD_TESTS
+const HMILanguageHandler::Apps& HMILanguageHandler::get_apps() const {
+  return apps_;
+}
+#endif  // BUILD_TESTS
+
 void HMILanguageHandler::OnUnregisterApplication(uint32_t app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(apps_lock_);

--- a/src/components/application_manager/src/hmi_language_handler.cc
+++ b/src/components/application_manager/src/hmi_language_handler.cc
@@ -346,12 +346,6 @@ void HMILanguageHandler::Init(resumption::LastState* value) {
   persisted_tts_language_ = get_language_for(INTERFACE_TTS);
 }
 
-#ifdef BUILD_TESTS
-const HMILanguageHandler::Apps& HMILanguageHandler::get_apps() const {
-  return apps_;
-}
-#endif  // BUILD_TESTS
-
 void HMILanguageHandler::OnUnregisterApplication(uint32_t app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(apps_lock_);

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -131,6 +131,7 @@ const char* speech_capabilities = "speechCapabilities";
 const char* vr_capabilities = "vrCapabilities";
 const char* audio_pass_thru_capabilities = "audioPassThruCapabilities";
 const char* pcm_stream_capabilities = "pcmStreamCapabilities";
+const char* audio_pass_thru_icon = "audioPassThruIcon";
 // PutFile
 const char* sync_file_name = "syncFileName";
 const char* file_name = "fileName";
@@ -348,6 +349,7 @@ const char* auto_complete_text = "autoCompleteText";
 const char* file = "file";
 const char* retry = "retry";
 const char* service = "service";
+const char* audio_pass_thru_icon = "audioPassThruIcon";
 }  // namespace hmi_request
 
 namespace hmi_response {

--- a/src/components/application_manager/test/CMakeLists.txt
+++ b/src/components/application_manager/test/CMakeLists.txt
@@ -57,6 +57,7 @@ set(testSources
   ${AM_TEST_DIR}/policy_event_observer_test.cc
   ${AM_TEST_DIR}/application_impl_test.cc
   ${AM_TEST_DIR}/hmi_capabilities_test.cc
+  ${AM_TEST_DIR}/hmi_language_handler_test.cc
   ${AM_TEST_DIR}/application_state_test.cc
   ${AM_TEST_DIR}/usage_statistics_test.cc
   ${AM_TEST_DIR}/policy_handler_test.cc

--- a/src/components/application_manager/test/hmi_language_handler_test.cc
+++ b/src/components/application_manager/test/hmi_language_handler_test.cc
@@ -1,0 +1,378 @@
+/*
+ * Copyright (c) 2017, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+
+#include "gtest/gtest.h"
+#include "application_manager/application_manager.h"
+#include "application_manager/hmi_language_handler.h"
+#include "application_manager/state_controller.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_event_dispatcher.h"
+#include "application_manager/mock_message_helper.h"
+#include "application_manager/resumption/resume_ctrl_impl.h"
+#include "application_manager/mock_hmi_capabilities.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/smart_object_keys.h"
+#include "resumption/last_state_impl.h"
+#include "utils/shared_ptr.h"
+#include "utils/make_shared.h"
+#include "utils/lock.h"
+
+namespace test {
+namespace components {
+namespace hmi_language_handler {
+
+namespace am = ::application_manager;
+
+using am::event_engine::Event;
+using am::ApplicationSet;
+using ::utils::SharedPtr;
+
+using ::testing::Return;
+using ::testing::ReturnRef;
+using ::testing::NiceMock;
+using ::testing::_;
+
+typedef NiceMock<
+    ::test::components::application_manager_test::MockApplicationManager>
+    MockApplicationManager;
+typedef NiceMock<
+    ::test::components::application_manager_test::MockHMICapabilities>
+    MockHMICapabilities;
+typedef NiceMock< ::test::components::event_engine_test::MockEventDispatcher>
+    MockEventDispatcher;
+typedef NiceMock<application_manager_test::MockApplication> MockApp;
+
+typedef SharedPtr<MockApp> ApplicationSharedPtr;
+typedef am::HMILanguageHandler::Apps Apps;
+
+namespace {
+const uint32_t kDefaultAppsSize = 0u;
+}  // namespace
+
+class HmiLanguageHandlerTest : public ::testing::Test {
+ public:
+  HmiLanguageHandlerTest()
+      : last_state_("app_storage_folder", "app_info_storage") {
+    EXPECT_CALL(app_manager_, event_dispatcher())
+        .WillOnce(ReturnRef(event_dispatcher_));
+    hmi_language_handler_ =
+        ::utils::MakeShared<am::HMILanguageHandler>(app_manager_);
+  }
+
+  void InitHMIAtciveLanguage(hmi_apis::Common_Language::eType ui_language,
+                             hmi_apis::Common_Language::eType vr_language,
+                             hmi_apis::Common_Language::eType tts_language) {
+    EXPECT_CALL(hmi_capabilities_, active_ui_language())
+        .WillRepeatedly(Return(ui_language));
+    EXPECT_CALL(hmi_capabilities_, active_vr_language())
+        .WillRepeatedly(Return(vr_language));
+    EXPECT_CALL(hmi_capabilities_, active_tts_language())
+        .WillRepeatedly(Return(tts_language));
+  }
+
+  void Init(hmi_apis::Common_Language::eType ui_language,
+            hmi_apis::Common_Language::eType vr_language,
+            hmi_apis::Common_Language::eType tts_language) {
+    InitHMIAtciveLanguage(ui_language, vr_language, tts_language);
+    hmi_language_handler_->set_default_capabilities_languages(
+        ui_language, vr_language, tts_language);
+  }
+
+  ApplicationSharedPtr CreateMockApp(const uint32_t app_id,
+                                     bool expect_call = false) const {
+    ApplicationSharedPtr app = ::utils::MakeShared<MockApp>();
+    if (expect_call) {
+      EXPECT_CALL(*app, app_id()).WillRepeatedly(Return(app_id));
+    } else {
+      ON_CALL(*app, app_id()).WillByDefault(Return(app_id));
+    }
+    return app;
+  }
+
+  void AddMockAppsToApplicationSet(ApplicationSet& app_set,
+                                   const uint32_t start_app_id,
+                                   uint32_t count,
+                                   bool expect_call = false) {
+    for (; count > 0; --count) {
+      app_set.insert(CreateMockApp(start_app_id + (count - 1), expect_call));
+    }
+  }
+
+  MockApplicationManager app_manager_;
+  MockHMICapabilities hmi_capabilities_;
+  MockEventDispatcher event_dispatcher_;
+  SharedPtr<am::HMILanguageHandler> hmi_language_handler_;
+  ::sync_primitives::Lock app_set_lock_;
+  resumption::LastStateImpl last_state_;
+};
+
+TEST_F(HmiLanguageHandlerTest, OnEvent_OnAppRegistered_SUCCESS) {
+  const Apps& kApps = hmi_language_handler_->get_apps();
+
+  ASSERT_EQ(kDefaultAppsSize, kApps.size());
+
+  // Create a message and set it to an event.
+  smart_objects::SmartObject msg;
+  msg[am::strings::params][am::strings::app_id] = 5u;
+
+  Event ev1(hmi_apis::FunctionID::BasicCommunication_OnAppRegistered);
+  ev1.set_smart_object(msg);
+
+  hmi_language_handler_->on_event(ev1);
+
+  // Expect that app been added to apps map.
+  EXPECT_EQ(1u, kApps.size());
+}
+
+TEST_F(HmiLanguageHandlerTest, OnEvent_AllLanguageIsReceivedAndSame_SUCCESS) {
+  // Repeatedly add events to set `is_*_language_received_` flags up
+
+  Event ev1(hmi_apis::FunctionID::UI_GetLanguage);
+  hmi_language_handler_->on_event(ev1);
+
+  Event ev2(hmi_apis::FunctionID::VR_GetLanguage);
+  hmi_language_handler_->on_event(ev2);
+
+  // After last flag gets up, `VerifyWithPersistedLanguages`
+  // method been called to and then will call `hmi_capabilities`
+  EXPECT_CALL(app_manager_, hmi_capabilities())
+      .WillOnce(ReturnRef(hmi_capabilities_));
+
+  // Set up `active_*_language` and
+  //`persisted_ui_language_` to be the same
+
+  hmi_language_handler_->Init(&last_state_);
+  Init(hmi_apis::Common_Language::eType::EN_US,
+       hmi_apis::Common_Language::eType::EN_US,
+       hmi_apis::Common_Language::eType::EN_US);
+  // Then `active_*_language` and
+  //`persisted_ui_language_` will be compared.
+  // So if they same app_manager_'s method `applications`
+  // will never be called.
+  EXPECT_CALL(app_manager_, applications()).Times(0);
+
+  Event ev3(hmi_apis::FunctionID::TTS_GetLanguage);
+  hmi_language_handler_->on_event(ev3);
+}
+
+TEST_F(HmiLanguageHandlerTest, OnEvent_AllReceivedLanguagesMismatch_SUCCESS) {
+  Event ev1(hmi_apis::FunctionID::UI_GetLanguage);
+  hmi_language_handler_->on_event(ev1);
+  Event ev2(hmi_apis::FunctionID::VR_GetLanguage);
+  hmi_language_handler_->on_event(ev2);
+
+  const Apps& kApps = hmi_language_handler_->get_apps();
+
+  ASSERT_EQ(kDefaultAppsSize, kApps.size());
+
+  EXPECT_CALL(app_manager_, hmi_capabilities())
+      .WillOnce(ReturnRef(hmi_capabilities_));
+
+  // Set up `active_*_language` and
+  //`persisted_ui_language_` to be different
+  hmi_language_handler_->set_default_capabilities_languages(
+      hmi_apis::Common_Language::eType::EN_US,
+      hmi_apis::Common_Language::eType::EN_US,
+      hmi_apis::Common_Language::eType::EN_US);
+
+  InitHMIAtciveLanguage(hmi_apis::Common_Language::eType::RU_RU,
+                        hmi_apis::Common_Language::eType::RU_RU,
+                        hmi_apis::Common_Language::eType::RU_RU);
+
+  ApplicationSet app_set;
+  const uint32_t kAppCount = 5u;
+  // Adding to app set `kAppCount` apps with app_id form 0 to `kAppCount`.
+  AddMockAppsToApplicationSet(app_set, 0u, kAppCount);
+
+  DataAccessor<ApplicationSet> data_accessor(app_set, app_set_lock_);
+
+  // Because `active_*_language` and
+  //`persisted_ui_language_` are different,
+  // the `applications` will be called and
+  // app data will checked by `CheckApplication` method
+  EXPECT_CALL(app_manager_, applications()).WillOnce(Return(data_accessor));
+
+  Event ev3(hmi_apis::FunctionID::TTS_GetLanguage);
+  hmi_language_handler_->on_event(ev3);
+
+  // Expect that app been added to apps map.
+  EXPECT_EQ(kAppCount, kApps.size());
+}
+
+TEST_F(HmiLanguageHandlerTest, OnEvent_AllReceivedLanguagesMismatch_UNSUCCESS) {
+  Event ev1(hmi_apis::FunctionID::UI_GetLanguage);
+  hmi_language_handler_->on_event(ev1);
+  Event ev2(hmi_apis::FunctionID::VR_GetLanguage);
+  hmi_language_handler_->on_event(ev2);
+
+  const Apps& kApps = hmi_language_handler_->get_apps();
+
+  ASSERT_EQ(kDefaultAppsSize, kApps.size());
+
+  EXPECT_CALL(app_manager_, hmi_capabilities())
+      .WillOnce(ReturnRef(hmi_capabilities_));
+
+  // Set up `active_*_language` and
+  //`persisted_ui_language_` to be different
+  hmi_language_handler_->set_default_capabilities_languages(
+      hmi_apis::Common_Language::eType::EN_US,
+      hmi_apis::Common_Language::eType::EN_US,
+      hmi_apis::Common_Language::eType::EN_US);
+
+  InitHMIAtciveLanguage(hmi_apis::Common_Language::eType::RU_RU,
+                        hmi_apis::Common_Language::eType::RU_RU,
+                        hmi_apis::Common_Language::eType::RU_RU);
+
+  ApplicationSet app_set;
+  DataAccessor<ApplicationSet> data_accessor(app_set, app_set_lock_);
+
+  // Send empty application set.
+  EXPECT_CALL(app_manager_, applications()).WillOnce(Return(data_accessor));
+
+  Event ev3(hmi_apis::FunctionID::TTS_GetLanguage);
+  hmi_language_handler_->on_event(ev3);
+}
+
+TEST_F(HmiLanguageHandlerTest,
+       SetHandleResponseRor_InvalidGetLanguage_UNSUCCESS) {
+  // Sending requests with invalid data
+  //`add_observer` method will be never called
+  const hmi_apis::FunctionID::eType kFunctionId =
+      hmi_apis::FunctionID::INVALID_ENUM;
+  const uint32_t kCorrelationId = 0u;
+
+  smart_objects::SmartObject request;
+
+  EXPECT_CALL(event_dispatcher_, add_observer(_, _, _)).Times(0);
+  hmi_language_handler_->set_handle_response_for(request);
+
+  request[am::strings::params] = 0u;
+
+  EXPECT_CALL(event_dispatcher_, add_observer(_, _, _)).Times(0);
+  hmi_language_handler_->set_handle_response_for(request);
+
+  request[am::strings::params][am::strings::function_id] = kFunctionId;
+
+  EXPECT_CALL(event_dispatcher_, add_observer(_, _, _)).Times(0);
+  hmi_language_handler_->set_handle_response_for(request);
+
+  request[am::strings::params][am::strings::correlation_id] = kCorrelationId;
+
+  EXPECT_CALL(event_dispatcher_, add_observer(_, _, _)).Times(0);
+  hmi_language_handler_->set_handle_response_for(request);
+}
+
+TEST_F(HmiLanguageHandlerTest,
+       SetHandleResponseRor_RequestsWithoutNeededKeys_SUCCESS) {
+  // Sending requests with valid data
+  //`add_observer` method will be called
+  const hmi_apis::FunctionID::eType kFunctionId =
+      hmi_apis::FunctionID::UI_GetLanguage;
+  const uint32_t kCorrelationId = 0u;
+
+  smart_objects::SmartObject request;
+  request[am::strings::params][am::strings::function_id] = kFunctionId;
+  request[am::strings::params][am::strings::correlation_id] = kCorrelationId;
+
+  EXPECT_CALL(event_dispatcher_, add_observer(kFunctionId, kCorrelationId, _));
+  hmi_language_handler_->set_handle_response_for(request);
+}
+
+TEST_F(HmiLanguageHandlerTest,
+       HandleWrongLanguageApp_UnregisteredAppId_SUCCESS) {
+  const Apps& kApps = hmi_language_handler_->get_apps();
+
+  ASSERT_EQ(kDefaultAppsSize, kApps.size());
+
+  smart_objects::SmartObject msg;
+  msg[am::strings::params][am::strings::app_id] = 5u;
+
+  Event ev1(hmi_apis::FunctionID::BasicCommunication_OnAppRegistered);
+  ev1.set_smart_object(msg);
+
+  EXPECT_CALL(app_manager_, hmi_capabilities()).Times(0);
+  hmi_language_handler_->on_event(ev1);
+
+  EXPECT_EQ(1u, kApps.size());
+
+  EXPECT_CALL(app_manager_, hmi_capabilities())
+      .WillOnce(ReturnRef(hmi_capabilities_));
+
+  // Set up `active_*_language` and
+  //`persisted_ui_language_` to be different
+  hmi_language_handler_->set_default_capabilities_languages(
+      hmi_apis::Common_Language::eType::EN_US,
+      hmi_apis::Common_Language::eType::EN_US,
+      hmi_apis::Common_Language::eType::EN_US);
+
+  InitHMIAtciveLanguage(hmi_apis::Common_Language::eType::EN_US,
+                        hmi_apis::Common_Language::eType::EN_US,
+                        hmi_apis::Common_Language::eType::EN_US);
+
+  // Needed to call of `ManageMobileCommand` method
+  EXPECT_CALL(*am::MockMessageHelper::message_helper_mock(),
+              GetOnAppInterfaceUnregisteredNotificationToMobile(_, _))
+      .WillOnce(Return(::utils::MakeShared<smart_objects::SmartObject>()));
+
+  // Wait for `ManageMobileCommand` call twice.
+  // First time in `SendOnLanguageChangeToMobile`
+  // method, second time in `HandleWrongLanguageApp`.
+  EXPECT_CALL(app_manager_, ManageMobileCommand(_, _)).Times(2);
+
+  EXPECT_CALL(app_manager_, UnregisterApplication(_, _, _, _)).Times(1);
+
+  hmi_language_handler_->on_event(ev1);
+
+  EXPECT_EQ(kDefaultAppsSize, kApps.size());
+}
+
+TEST_F(HmiLanguageHandlerTest, OnUnregisterApp_SUCCESS) {
+  const uint32_t app_id = 5u;
+  smart_objects::SmartObject msg;
+  msg[am::strings::params][am::strings::app_id] = app_id;
+
+  Event event(hmi_apis::FunctionID::BasicCommunication_OnAppRegistered);
+  event.set_smart_object(msg);
+
+  hmi_language_handler_->on_event(event);
+
+  EXPECT_EQ(1u, hmi_language_handler_->get_apps().size());
+
+  hmi_language_handler_->OnUnregisterApplication(app_id);
+  EXPECT_EQ(kDefaultAppsSize, hmi_language_handler_->get_apps().size());
+}
+
+}  // namespace hmi_language_handler
+}  // namespace components
+}  // namespace test

--- a/src/components/connection_handler/CMakeLists.txt
+++ b/src/components/connection_handler/CMakeLists.txt
@@ -31,11 +31,11 @@
 include(${CMAKE_SOURCE_DIR}/tools/cmake/helpers/sources.cmake)
 
 include_directories (
-    include
-    ${COMPONENTS_DIR}/protocol_handler/include/
-    ${COMPONENTS_DIR}/utils/include/
-    ${ENCRYPTION_INCLUDE_DIRECTORY}
-    ${LOG4CXX_INCLUDE_DIRECTORY}
+  include
+  ${COMPONENTS_DIR}/protocol_handler/include/
+  ${COMPONENTS_DIR}/utils/include/
+  ${ENCRYPTION_INCLUDE_DIRECTORY}
+  ${LOG4CXX_INCLUDE_DIRECTORY}
 )
 
 set(PATHS
@@ -44,8 +44,9 @@ set(PATHS
 )
 
 set(LIBRARIES
-    ProtocolLibrary
-    encryption
+  ProtocolLibrary
+  encryption
+  Utils
 )
 
 collect_sources(SOURCES "${PATHS}")

--- a/src/components/dbus/CMakeLists.txt
+++ b/src/components/dbus/CMakeLists.txt
@@ -50,14 +50,16 @@ set(PATHS
 collect_sources(SOURCES "${PATHS}")
 
 set(LIBRARIES
+  HMI_API
+  Utils
   dbus-1 -L${DBUS_LIBS_DIRECTORY}
 )
 
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/message_descriptions.cc
   COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/codegen/make_message_descriptions.py
-  --infile ${CMAKE_CURRENT_SOURCE_DIR}/../interfaces/QT_HMI_API.xml
-  --outdir ${CMAKE_CURRENT_BINARY_DIR}
+    --infile ${CMAKE_CURRENT_SOURCE_DIR}/../interfaces/QT_HMI_API.xml
+    --outdir ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../interfaces/QT_HMI_API.xml
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/make_message_descriptions.py
 )
@@ -65,8 +67,8 @@ add_custom_command(
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/introspection_xml.cc
   COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/codegen/make_introspection_c.py
-  --infile ${CMAKE_CURRENT_SOURCE_DIR}/../interfaces/QT_HMI_API.xml
-  --outdir ${CMAKE_CURRENT_BINARY_DIR}
+    --infile ${CMAKE_CURRENT_SOURCE_DIR}/../interfaces/QT_HMI_API.xml
+    --outdir ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../interfaces/QT_HMI_API.xml
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/make_introspection_c.py
 )

--- a/src/components/formatters/CMakeLists.txt
+++ b/src/components/formatters/CMakeLists.txt
@@ -45,8 +45,14 @@ set(PATHS
   ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
+set (LIBRARIES
+  Utils
+  SmartObjects  
+)
+
 collect_sources(SOURCES "${PATHS}")
-add_library(formatters ${SOURCES})
+add_library("formatters" ${SOURCES})
+target_link_libraries("formatters" "${LIBRARIES}")
 
 if(BUILD_TESTS)
   add_subdirectory(test)

--- a/src/components/interfaces/CMakeLists.txt
+++ b/src/components/interfaces/CMakeLists.txt
@@ -70,4 +70,7 @@ if(HMI_DBUS_API)
   add_library(HMI_API ${CMAKE_CURRENT_BINARY_DIR}/HMI_API_schema.cc)
 endif()
 
-add_dependencies(HMI_API Utils)
+target_link_libraries(v4_protocol_v1_2_no_extra Utils)
+target_link_libraries(MOBILE_API Utils)
+target_link_libraries(HMI_API Utils)
+

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -497,6 +497,9 @@
   <element name="phoneNumber">
     <description> Optional hone number of intended location / establishment (if applicable) for SendLocation.</description>
   </element>
+  <element name="audioPassThruIcon">
+	<description>The optional image field for AudioPassThru</description>
+  </element>
   <element name="timeToDestination"/>
     <!-- TO DO to be removed -->
     <element name="turnText"/>
@@ -538,6 +541,9 @@
   </element>
   <element name="locationImage">
     <description>The optional image of a destination / location</description>
+  </element>
+  <element name="audiPassThruIcon">
+    <description>The optional image for AudioPassThru</description>
   </element>
 </enum>
 
@@ -3203,6 +3209,12 @@
         If omitted, the value is set to true.
       </description>
     </param>
+    <param name="audioPassThruIcon" type="Common.Image" mandatory="false">
+	  <description>
+	    Image struct determinig wheter static or dynamic icon.
+		If omitted on supported displays, no (or the default if applicable) icon shall be displayed.
+	  </description>
+	</param>
   </function>
   <function name="PerformAudioPassThru" messagetype="response">
   </function>

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -34,7 +34,7 @@
 
 <interfaces name="SmartDeviceLink HMI API">
 
-<interface name="Common" version="1.4" date="2016-05-11">
+<interface name="Common" version="1.5" date="2017-01-16">
 
 <enum name="Result">
     <element name="SUCCESS" value="0"/>
@@ -498,7 +498,7 @@
     <description> Optional hone number of intended location / establishment (if applicable) for SendLocation.</description>
   </element>
   <element name="audioPassThruIcon">
-	<description>The optional image field for AudioPassThru</description>
+    <description>The optional image field for AudioPassThru</description>
   </element>
   <element name="timeToDestination"/>
     <!-- TO DO to be removed -->
@@ -2758,7 +2758,7 @@
   </function>
 </interface>
 
-<interface name="UI" version="1.0" date="2013-04-16">
+<interface name="UI" version="1.1" date="2017-01-16">
   <function name="Alert" messagetype="request">
     <description>Request from SDL to show an alert message on the display.</description>
     <param name="alertStrings" type="Common.TextFieldStruct" mandatory="true" array="true" minsize="0" maxsize="3">
@@ -3210,11 +3210,11 @@
       </description>
     </param>
     <param name="audioPassThruIcon" type="Common.Image" mandatory="false">
-	  <description>
-	    Image struct determinig wheter static or dynamic icon.
-		If omitted on supported displays, no (or the default if applicable) icon shall be displayed.
-	  </description>
-	</param>
+      <description>
+        Image struct determinig wheter static or dynamic icon.
+        If omitted on supported displays, no (or the default if applicable) icon shall be displayed.
+      </description>
+    </param>
   </function>
   <function name="PerformAudioPassThru" messagetype="response">
   </function>

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -747,6 +747,10 @@
       <description>The optional image of a destination / location</description>
     </element>
 
+    <element name="audioPassThruIcon">
+      <description>The optional image field for AudioPassThru</description>
+    </element>
+
   </enum>
 
   <enum name="CharacterSet">
@@ -3393,6 +3397,10 @@
 		Defines if the current audio source should be muted during the APT session.  If not, the audio source will play without interruption.
       	If omitted, the value is set to true.
       </description>
+    </param>
+    <param name="audioPassThruIcon" type="Image" mandatory="false">
+      <description>Image struct determinig wheter static or dynamic icon.
+        If omitted on supported displays, no (or the default if applicable) icon shall be displayed.</description>
     </param>
   </function>
 

--- a/src/components/media_manager/CMakeLists.txt
+++ b/src/components/media_manager/CMakeLists.txt
@@ -32,21 +32,21 @@ include(${CMAKE_SOURCE_DIR}/tools/cmake/helpers/platform.cmake)
 include(${CMAKE_SOURCE_DIR}/tools/cmake/helpers/sources.cmake)
 
 include_directories(
-    include
-    ${COMPONENTS_DIR}/media_manager/include/audio/
-    ${COMPONENTS_DIR}/media_manager/include/video/
-    ${COMPONENTS_DIR}/utils/include/
-    ${COMPONENTS_DIR}/protocol_handler/include/
-    ${COMPONENTS_DIR}/connection_handler/include/
-    ${COMPONENTS_DIR}/application_manager/include/
-    ${COMPONENTS_DIR}/smart_objects/include/
-    ${COMPONENTS_DIR}/hmi_message_handler/include/
-    ${COMPONENTS_DIR}/formatters/include/
-    ${COMPONENTS_DIR}/config_profile/include/
-    ${JSONCPP_INCLUDE_DIRECTORY}
-    ${CMAKE_BINARY_DIR}/src/components/
-    ${COMPONENTS_DIR}/policy/include/
-    ${LOG4CXX_INCLUDE_DIRECTORY}
+  include
+  ${COMPONENTS_DIR}/media_manager/include/audio/
+  ${COMPONENTS_DIR}/media_manager/include/video/
+  ${COMPONENTS_DIR}/utils/include/
+  ${COMPONENTS_DIR}/protocol_handler/include/
+  ${COMPONENTS_DIR}/connection_handler/include/
+  ${COMPONENTS_DIR}/application_manager/include/
+  ${COMPONENTS_DIR}/smart_objects/include/
+  ${COMPONENTS_DIR}/hmi_message_handler/include/
+  ${COMPONENTS_DIR}/formatters/include/
+  ${COMPONENTS_DIR}/config_profile/include/
+  ${JSONCPP_INCLUDE_DIRECTORY}
+  ${CMAKE_BINARY_DIR}/src/components/
+  ${COMPONENTS_DIR}/policy/include/
+  ${LOG4CXX_INCLUDE_DIRECTORY}
 )
 
 set(PATHS
@@ -59,7 +59,9 @@ set(EXCLUDE_PATHS
 )
 
 set(LIBRARIES
-    ProtocolLibrary
+  MOBILE_API
+  ProtocolLibrary
+  Utils
 )
 
 if(EXTENDED_MEDIA_MODE)
@@ -74,9 +76,6 @@ if(EXTENDED_MEDIA_MODE)
     ${GSTREAMER_gstconfig_INCLUDE_DIR}
     ${GLIB_glib_2_INCLUDE_DIR}
   )
-  list(APPEND EXCLUDE_PATHS
-
-  )
   list(APPEND LIBRARIES
     ${GSTREAMER_gstreamer_LIBRARY}
     pulse-simple
@@ -86,9 +85,9 @@ if(EXTENDED_MEDIA_MODE)
   )
 else()
   list(APPEND EXCLUDE_PATHS
-	a2dp_source_player_adapter.cc
-	from_mic_recorder_adapter.cc
-	from_mic_to_file_recorder_thread.cc
+    a2dp_source_player_adapter.cc
+    from_mic_recorder_adapter.cc
+    from_mic_to_file_recorder_thread.cc
   )
 endif()
 
@@ -97,9 +96,9 @@ add_library("MediaManager" ${SOURCES})
 target_link_libraries("MediaManager" ${LIBRARIES})
 
 if(ENABLE_LOG)
-    target_link_libraries("MediaManager" log4cxx -L${LOG4CXX_LIBS_DIRECTORY})
+  target_link_libraries("MediaManager" log4cxx -L${LOG4CXX_LIBS_DIRECTORY})
 endif()
 
 if(BUILD_TESTS)
-    add_subdirectory(test)
+  add_subdirectory(test)
 endif()

--- a/src/components/policy/CMakeLists.txt
+++ b/src/components/policy/CMakeLists.txt
@@ -54,6 +54,7 @@ set(USAGE_STATISTICS_PATHS
 )
 collect_sources(USAGE_STATISTICS_SOURCES "${USAGE_STATISTICS_PATHS}")
 add_library(UsageStatistics ${USAGE_STATISTICS_SOURCES})
+target_link_libraries(UsageStatistics Utils)
 
 set(EXCLUDE_PATHS
   ${POLICY_TABLE_PATHS}

--- a/src/components/resumption/CMakeLists.txt
+++ b/src/components/resumption/CMakeLists.txt
@@ -45,6 +45,7 @@ set(PATHS
 collect_sources(SOURCES "${PATHS}")
 
 add_library("Resumption" ${SOURCES})
+target_link_libraries("Resumption" Utils)
 
 if(BUILD_TESTS)
   add_subdirectory(test)

--- a/src/components/rpc_base/CMakeLists.txt
+++ b/src/components/rpc_base/CMakeLists.txt
@@ -44,6 +44,7 @@ collect_sources(SOURCES "${PATHS}")
 
 set(LIBRARIES
   jsoncpp
+  Utils
 )
 
 add_library(rpc_base ${SOURCES})

--- a/src/components/security_manager/CMakeLists.txt
+++ b/src/components/security_manager/CMakeLists.txt
@@ -50,6 +50,7 @@ set(PATHS
 collect_sources(SOURCES "${PATHS}")
 
 set(LIBRARIES
+  Utils
   crypto
   ssl
   ProtocolHandler

--- a/src/components/smart_objects/CMakeLists.txt
+++ b/src/components/smart_objects/CMakeLists.txt
@@ -43,6 +43,7 @@ set(PATHS
 collect_sources(SOURCES "${PATHS}")
 
 add_library("SmartObjects" ${SOURCES})
+target_link_libraries("SmartObjects" Utils)
 
 if(ENABLE_LOG)
   target_link_libraries("SmartObjects" log4cxx -L${LOG4CXX_LIBS_DIRECTORY})

--- a/src/components/telemetry_monitor/CMakeLists.txt
+++ b/src/components/telemetry_monitor/CMakeLists.txt
@@ -57,6 +57,8 @@ collect_sources(SOURCES "${PATHS}")
 set(LIBRARIES
   HMI_API
   MOBILE_API
+  Utils
+  Policy
 )
 
 add_library("TelemetryMonitor" ${SOURCES})

--- a/src/components/transport_manager/CMakeLists.txt
+++ b/src/components/transport_manager/CMakeLists.txt
@@ -52,6 +52,7 @@ set(EXCLUDE_PATHS)
 
 set(LIBRARIES
   ProtocolLibrary
+  Utils
 )
 
 if(BUILD_BT_SUPPORT)

--- a/src/plugins/appenders/CMakeLists.txt
+++ b/src/plugins/appenders/CMakeLists.txt
@@ -43,6 +43,8 @@ set(LIBRARIES
 add_library(appenders ${SOURCES})
 target_link_libraries(appenders ${LIBRARIES})
 
+add_dependencies(appenders install-3rd_party_logger)
+
 install(TARGETS appenders
   DESTINATION bin
   PERMISSIONS

--- a/tools/intergen/GenerateInterfaceLibrary.cmake
+++ b/tools/intergen/GenerateInterfaceLibrary.cmake
@@ -51,6 +51,7 @@ function (GenerateInterfaceLibrary xml_file_name generated_interface_names)
       ${GENERATED_LIB_HEADER_DEPENDENCIES}
     )
     add_library(${interface_name} ${SOURCES})
+    add_dependencies(${interface_name} intergen)
 
     # |previous_interface| ensures that interface libraries are built in the same order
     # as they defined in |generated_interface_names|


### PR DESCRIPTION
Moved application manager implementation tests from pre_5_0_0 branch to develop

Added:
- application_manager_impl_test.cc file which contains 5 working unit test cases for ApplicationManagerImpl class:
   - ProcessQueryApp_ExpectSuccess
   - SubscribeAppForWayPoints_ExpectSubscriptionApp
   - UnsubscribeAppForWayPoints_ExpectUnsubscriptionApp
   - IsAnyAppSubscribedForWayPoints_SubcribeAppForWayPoints_ExpectCorrectResult
   - GetAppsSubscribedForWayPoints_SubcribeAppForWayPoints_ExpectCorrectResult
- New mock method for CreateDeviceListSO call with 3 parameters into mock_message_helper.h
- CreateDeviceListSO method mock implementation into mock_message_helper.cc
- New header file mock_hmi_message_handler, which is a mock class for HMIMessageHandler class